### PR TITLE
Solve issue related to serialization causing a hard crash on start

### DIFF
--- a/src/Main.kt
+++ b/src/Main.kt
@@ -27,6 +27,7 @@ import kotlinx.serialization.protobuf.ProtoBuf
 
 @Serializable
 data class DataSession(val id: String, val redirectUri: String)
+@Serializable
 data class Session(val id: String)
 
 @OptIn(ExperimentalSerializationApi::class)


### PR DESCRIPTION
Currently, trying to boot up the default docker images, it hard crashes due to serialization. This fixes it.