### PR TITLE
change the callback id from an Int to a Long

### DIFF
--- a/src/main/kotlin/Resource.kt
+++ b/src/main/kotlin/Resource.kt
@@ -10,7 +10,7 @@ class Telegram {
 
     @Resource("callback")
     class Callback(
-        val id: Int,
+        val id: Long,
         @SerialName("first_name")
         val firstName: String? = null,
         @SerialName("last_name")


### PR DESCRIPTION
We have users who have IDs above the Integer maximum. Changing to Long would allow bigger numbers.